### PR TITLE
经实测 buffer 第一个 500毫秒不会发出500毫秒时刻的值

### DIFF
--- a/docs/content/operators-time.md
+++ b/docs/content/operators-time.md
@@ -156,10 +156,10 @@ TODO
 ```javascript
 let scissor$ = Rx.Observable.interval(500)
 
-let emitter$ = Rx.Observable.interval(100).take(10) // 总共会输出10个值
+let emitter$ = Rx.Observable.interval(100).take(10) // 总共会输出9个值
 .buffer( scissor$ )
 
-// 500毫秒后输出: [0,1,2,3,4]  1秒后输出: [5,6,7,8,9]
+// 500毫秒后输出: [0,1,2,3]  1秒后输出: [4,5,6,7,8]
 ```
 
 弹珠图


### PR DESCRIPTION
我使用 angular 6.0.3, rxjs 使用 6.2.2 版本,按照你们的方法使用 buffer, 得出不一样的输出,代码如下

        let scissor = interval(500)
        let emitter = interval(100)
        // 会生成 10 个 值
        let timeTake = take(10)
        let emitterTake = timeTake(emitter)

        let rxBuffer =  buffer(scissor)
        let stream$ = rxBuffer(emitterTake)
        stream$.subscribe(d => {
            // 500 毫秒后 生成 [ 0, 1, 2, 3]
            // 再过 500 毫秒后 生成 [4, 5, 6, 7，8]
            console.log('d', d)
        })
``